### PR TITLE
Add text-to-video generation pipeline

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+opencv-python
+Pillow

--- a/tests/test_text_to_video.py
+++ b/tests/test_text_to_video.py
@@ -1,0 +1,16 @@
+from text_to_video.pipeline import StoryboardBuilder, FrameRenderer, StoryboardSegment
+
+
+def test_storyboard_builder_splits_long_text():
+    builder = StoryboardBuilder(seconds_per_segment=2.0, max_chars=40)
+    text = "Yapay zeka metinleri sahnelere dönüştürür. Her sahne video içinde belirli bir süre kalır."
+    segments = builder.build(text)
+    assert len(segments) == 2
+    assert all(segment.duration == 2.0 for segment in segments)
+
+
+def test_frame_renderer_output_shape():
+    renderer = FrameRenderer(width=640, height=360)
+    segment = StoryboardSegment(text="Merhaba dünya", duration=1.0)
+    frame = renderer.render(segment)
+    assert frame.shape == (360, 640, 3)

--- a/text_to_video/README.md
+++ b/text_to_video/README.md
@@ -1,0 +1,40 @@
+# Metinden Video Üretici
+
+Bu modül, sağlanan metni temel alarak her cümleyi sahneye dönüştüren basit bir yapay zekâ destekli video üretim hattı sunar. Sistem, metni sahnelere böler, her sahne için metin odaklı bir görsel üretir ve bu kareleri OpenCV yardımıyla MP4 formatında birleştirir.
+
+## Kurulum
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+OpenCV'nin MP4 çıktısı üretebilmesi için sisteminizde uygun codec'lerin kurulu olması gerekir.
+
+## Kullanım
+
+```bash
+python -m text_to_video.main "Metninizi buraya yazın" --output video.mp4
+```
+
+Alternatif olarak metni bir dosyadan da okuyabilirsiniz:
+
+```bash
+python -m text_to_video.main --input-file senaryo.txt --output video.mp4
+```
+
+### Parametreler
+
+- `--width` ve `--height`: Videonun çözünürlüğü.
+- `--fps`: Saniyedeki kare sayısı.
+- `--seconds-per-segment`: Her sahnenin süresi.
+- `--font`: Özel bir `.ttf` yazı tipi dosyası kullanmak için yol belirtin.
+
+## Nasıl Çalışır?
+
+1. **Storyboard oluşturma:** `StoryboardBuilder` metni cümlelere böler ve her cümle için arka plan rengi seçer.
+2. **Kare render etme:** `FrameRenderer`, Pillow kullanarak metni büyük puntolu olarak karelere yazar.
+3. **Video derleme:** `VideoAssembler`, render edilen kareleri verilen FPS değerine göre MP4 videoya çevirir.
+
+Bu yaklaşım, hızlı prototip oluşturmak ve metinden kısa tanıtım videoları üretmek için uygundur. Daha gelişmiş senaryolar için segment başına farklı görseller veya seslendirme modülleri eklemek üzere kodu genişletebilirsiniz.

--- a/text_to_video/__init__.py
+++ b/text_to_video/__init__.py
@@ -1,0 +1,5 @@
+"""Text-to-video generation utilities."""
+
+from .pipeline import TextToVideoPipeline, StoryboardSegment
+
+__all__ = ["TextToVideoPipeline", "StoryboardSegment"]

--- a/text_to_video/main.py
+++ b/text_to_video/main.py
@@ -1,0 +1,53 @@
+"""Command line entry point for the text-to-video generator."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Optional
+
+from .pipeline import TextToVideoPipeline
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate a simple AI-assisted video from text.")
+    parser.add_argument("text", nargs="?", help="Text to convert into a video. If omitted, --input-file is required.")
+    parser.add_argument("--input-file", type=Path, help="Path to a UTF-8 text file to read the script from.")
+    parser.add_argument("--output", type=Path, default=Path("output.mp4"), help="Path for the generated video file.")
+    parser.add_argument("--width", type=int, default=1280, help="Output video width in pixels.")
+    parser.add_argument("--height", type=int, default=720, help="Output video height in pixels.")
+    parser.add_argument("--fps", type=int, default=24, help="Frames per second for the video.")
+    parser.add_argument(
+        "--seconds-per-segment",
+        type=float,
+        default=4.0,
+        help="Duration of each generated scene in seconds.",
+    )
+    parser.add_argument("--font", type=str, default=None, help="Optional path to a .ttf font file for rendering text.")
+    return parser
+
+
+def read_text(text_argument: Optional[str], input_file: Optional[Path]) -> str:
+    if text_argument:
+        return text_argument
+    if input_file and input_file.exists():
+        return input_file.read_text(encoding="utf-8")
+    raise SystemExit("Either text argument or --input-file must be provided.")
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    script_text = read_text(args.text, args.input_file)
+    pipeline = TextToVideoPipeline(
+        width=args.width,
+        height=args.height,
+        fps=args.fps,
+        seconds_per_segment=args.seconds_per_segment,
+        font_path=args.font,
+    )
+    pipeline.run(script_text, str(args.output))
+    print(f"Video generated at {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/text_to_video/pipeline.py
+++ b/text_to_video/pipeline.py
@@ -1,0 +1,190 @@
+"""Core pipeline for generating short videos from text prompts."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+import math
+import os
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+import cv2
+
+
+@dataclass
+class StoryboardSegment:
+    """A single segment in the generated storyboard."""
+
+    text: str
+    duration: float = 4.0
+    background_color: tuple[int, int, int] = field(default_factory=lambda: (18, 18, 18))
+    text_color: tuple[int, int, int] = field(default_factory=lambda: (245, 245, 245))
+
+    def normalized(self) -> "StoryboardSegment":
+        duration = max(self.duration, 0.5)
+        return StoryboardSegment(
+            text=self.text.strip(),
+            duration=duration,
+            background_color=self.background_color,
+            text_color=self.text_color,
+        )
+
+
+class StoryboardBuilder:
+    """Split an input text into visually pleasing storyboard segments."""
+
+    def __init__(self, seconds_per_segment: float = 4.0, max_chars: int = 150) -> None:
+        self.seconds_per_segment = seconds_per_segment
+        self.max_chars = max_chars
+
+    def build(self, text: str) -> List[StoryboardSegment]:
+        sentences = self._split_sentences(text)
+        segments: List[StoryboardSegment] = []
+        for sentence in sentences:
+            if not sentence:
+                continue
+            color = self._color_from_text(sentence)
+            segments.append(
+                StoryboardSegment(
+                    text=sentence,
+                    duration=self.seconds_per_segment,
+                    background_color=color,
+                    text_color=self._ideal_text_color(color),
+                )
+            )
+        return [segment.normalized() for segment in segments]
+
+    def _split_sentences(self, text: str) -> List[str]:
+        raw = [chunk.strip() for chunk in text.replace("\n", " ").split(".")]
+        sentences: List[str] = []
+        buffer = ""
+        for chunk in raw:
+            if not chunk:
+                continue
+            candidate = (buffer + " " + chunk).strip() if buffer else chunk
+            if len(candidate) <= self.max_chars:
+                buffer = candidate
+            else:
+                if buffer:
+                    sentences.append(buffer)
+                buffer = chunk
+        if buffer:
+            sentences.append(buffer)
+        return [sentence + "." if not sentence.endswith(".") else sentence for sentence in sentences]
+
+    def _color_from_text(self, text: str) -> tuple[int, int, int]:
+        digest = hashlib.sha256(text.encode("utf-8")).digest()
+        return tuple(int(digest[i]) for i in range(3))
+
+    def _ideal_text_color(self, rgb: tuple[int, int, int]) -> tuple[int, int, int]:
+        r, g, b = rgb
+        luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+        return (20, 20, 20) if luminance > 128 else (245, 245, 245)
+
+
+class FrameRenderer:
+    """Render storyboard segments into RGB frames."""
+
+    def __init__(
+        self,
+        width: int = 1280,
+        height: int = 720,
+        font_path: Optional[str] = None,
+        font_size: int = 48,
+        margin: int = 60,
+    ) -> None:
+        self.width = width
+        self.height = height
+        self.margin = margin
+        self.font = self._load_font(font_path, font_size)
+
+    def render(self, segment: StoryboardSegment) -> np.ndarray:
+        img = Image.new("RGB", (self.width, self.height), color=segment.background_color)
+        draw = ImageDraw.Draw(img)
+        wrapped = self._wrap_text(segment.text)
+        current_y = self.margin
+        for line in wrapped:
+            w, h = draw.textsize(line, font=self.font)
+            x = (self.width - w) / 2
+            draw.text((x, current_y), line, fill=segment.text_color, font=self.font)
+            current_y += h + 10
+        return np.array(img)
+
+    def _wrap_text(self, text: str) -> List[str]:
+        draw = ImageDraw.Draw(Image.new("RGB", (self.width, self.height)))
+        words = text.split()
+        lines: List[str] = []
+        current_line: List[str] = []
+        for word in words:
+            test_line = " ".join(current_line + [word]).strip()
+            w, _ = draw.textsize(test_line, font=self.font)
+            if w <= self.width - self.margin * 2 or not current_line:
+                current_line.append(word)
+            else:
+                lines.append(" ".join(current_line))
+                current_line = [word]
+        if current_line:
+            lines.append(" ".join(current_line))
+        return lines
+
+    def _load_font(self, font_path: Optional[str], font_size: int) -> ImageFont.FreeTypeFont:
+        if font_path and os.path.exists(font_path):
+            return ImageFont.truetype(font_path, font_size)
+        try:
+            return ImageFont.truetype("DejaVuSans.ttf", font_size)
+        except OSError:
+            return ImageFont.load_default()
+
+
+class VideoAssembler:
+    """Convert frames to a playable MP4 video using OpenCV."""
+
+    def __init__(self, output_path: str, fps: int, frame_size: tuple[int, int]) -> None:
+        self.output_path = output_path
+        self.fps = fps
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+        width, height = frame_size
+        self.writer = cv2.VideoWriter(output_path, fourcc, fps, (width, height))
+        if not self.writer.isOpened():
+            raise RuntimeError("Video writer could not be initialized. Ensure the correct codecs are installed.")
+
+    def write_frame(self, frame: np.ndarray, duration: float) -> None:
+        frame_bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+        frames_to_write = max(1, int(math.ceil(duration * (self.fps or 1))))
+        for _ in range(frames_to_write):
+            self.writer.write(frame_bgr)
+
+    def close(self) -> None:
+        self.writer.release()
+
+
+class TextToVideoPipeline:
+    """High-level orchestrator that converts raw text into a short narrated video."""
+
+    def __init__(
+        self,
+        width: int = 1280,
+        height: int = 720,
+        fps: int = 24,
+        seconds_per_segment: float = 4.0,
+        font_path: Optional[str] = None,
+    ) -> None:
+        self.width = width
+        self.height = height
+        self.fps = fps
+        self.storyboard_builder = StoryboardBuilder(seconds_per_segment=seconds_per_segment)
+        self.renderer = FrameRenderer(width=width, height=height, font_path=font_path)
+
+    def run(self, text: str, output_path: str) -> List[StoryboardSegment]:
+        segments = self.storyboard_builder.build(text)
+        assembler = VideoAssembler(output_path=output_path, fps=self.fps, frame_size=(self.width, self.height))
+        try:
+            for segment in segments:
+                frame = self.renderer.render(segment)
+                assembler.write_frame(frame, duration=segment.duration)
+        finally:
+            assembler.close()
+        return segments


### PR DESCRIPTION
## Summary
- add a modular text-to-video pipeline that builds storyboards, renders frames, and assembles MP4 output
- expose a CLI for generating videos from inline text or script files
- document setup requirements and add smoke tests for storyboard splitting and frame rendering

## Testing
- not run (missing optional dependencies in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ddcf74e1508325832d81dd3e2a0d7f